### PR TITLE
Updating flake inputs jeu 05 jun 2025 21:39:45 CEST

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1727447169,
-        "narHash": "sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE+ne0U=",
+        "lastModified": 1749105467,
+        "narHash": "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "aa07eb05537d4cd025e2310397a6adcedfe72c76",
+        "rev": "6bc76b872374845ba9d645a2f012b764fecd765f",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748737919,
-        "narHash": "sha256-5kvBbLYdp+n7Ftanjcs6Nv+UO6sBhelp6MIGJ9nWmjQ=",
+        "lastModified": 1749131129,
+        "narHash": "sha256-tJ+93i7N4QttM75bE8T09LlSU3Mv6Dfi9WaVBvlWilo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5675a9686851d9626560052a032c4e14e533c1fa",
+        "rev": "13a45ede6c17b5e923dfc18a40a3f646436f4809",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748634340,
-        "narHash": "sha256-pZH4bqbOd8S+si6UcfjHovWDiWKiIGRNRMpmRWaDIms=",
+        "lastModified": 1749056381,
+        "narHash": "sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "daa628a725ab4948e0e2b795e8fb6f4c3e289a7a",
+        "rev": "029bd66faa180e11262dd1bc2732254c33415f52",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1748780463,
-        "narHash": "sha256-ractU3zRifAqWkUq+V6u1F1+QpdknTLZMm+34ne6CDE=",
+        "lastModified": 1749151952,
+        "narHash": "sha256-a/rsy4zr/D38WBbMJ5Y9vz9Ya2U1KNlS93UOoAs25Yo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8d7795a14435294d0b5f8cb1b8a9d791328a0ab",
+        "rev": "de8110976b2c91470b83250110914f4efb6bbf1c",
         "type": "github"
       },
       "original": {
@@ -429,11 +429,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748662220,
-        "narHash": "sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es=",
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59138c7667b7970d205d6a05a8bfa2d78caa3643",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748778828,
-        "narHash": "sha256-8S5G9xO7qoMMO2K85/mZSpFUJzgJJJF3xU5/mHuFJbY=",
+        "lastModified": 1749092205,
+        "narHash": "sha256-2QTM4E7QljCYsGNnCiibgFjx/K5hvQ7VkCHDY05rU4Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2786e3c51859ba35e77445105ba32d0a8f894a0f",
+        "rev": "bf9746362fc9a50cdf053883f0c06a4d9b93e3ca",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating flake inputs jeu 05 jun 2025 21:39:45 CEST




```shell
$ nix flake update
```
```shell

Host: x13
<<< x13.current
>>> x13.next
Version changes:
[U.]  #01  bootspec            1.0.0 -> 1.0.1
[U.]  #02  chromium            137.0.7151.55, 137.0.7151.55-sandbox -> 137.0.7151.68, 137.0.7151.68-sandbox
[U.]  #03  chromium-unwrapped  137.0.7151.55, 137.0.7151.55-sandbox -> 137.0.7151.68, 137.0.7151.68-sandbox
[U.]  #04  electron            35.5.0 -> 36.3.2
[U.]  #05  electron-unwrapped  35.5.0 -> 36.3.2
[U.]  #06  gh-dash             4.15.0, 4.15.0-fish-completions -> 4.16.0, 4.16.0-fish-completions
[U.]  #07  libkate             0.4.1 -> 0.4.3
[U*]  #08  netbird             0.45.1 x2, 0.45.1-fish-completions, 0.45.1-wrapper-netbird -> 0.45.2 x2, 0.45.2-fish-completions, 0.45.2-wrapper-netbird
[U.]  #09  nixos-system-x13    25.11.20250531.910796c -> 25.11.20250603.c2a0396
[U.]  #10  ruff                0.11.11 -> 0.11.12
[U.]  #11  signal-desktop      7.54.0, 7.54.0-fish-completions -> 7.56.0, 7.56.0-fish-completions
[U.]  #12  winbox              4.0beta20, 4.0beta20-fish-completions -> 4.0beta21, 4.0beta21-fish-completions
Added packages:
[A.]  #1  1zw47fx5h4x65n914j4b9iz0j3v17aw0-source  <none>
Removed packages:
[R.]  #1  dax78flrvcdir20swzlcm64va09nh5x8-source  <none>
Closure size: 2401 -> 2401 (100 paths added, 100 paths removed, delta +0, disk usage +8.6MiB).

Host: x260
<<< x260.current
>>> x260.next
Version changes:
[U.]  #1  bootspec           1.0.0 -> 1.0.1
[U.]  #2  gh-dash            4.15.0, 4.15.0-fish-completions -> 4.16.0, 4.16.0-fish-completions
[U.]  #3  libkate            0.4.1 -> 0.4.3
[U*]  #4  netbird            0.45.1 x2, 0.45.1-fish-completions, 0.45.1-wrapper-netbird -> 0.45.2 x2, 0.45.2-fish-completions, 0.45.2-wrapper-netbird
[U.]  #5  nixos-system-x260  25.11.20250531.910796c -> 25.11.20250603.c2a0396
[U.]  #6  ruff               0.11.11 -> 0.11.12
[U.]  #7  winbox             4.0beta20, 4.0beta20-fish-completions -> 4.0beta21, 4.0beta21-fish-completions
Added packages:
[A.]  #1  1zw47fx5h4x65n914j4b9iz0j3v17aw0-source  <none>
[A.]  #2  initrd-shells                            <none>
Removed packages:
[R.]  #1  dax78flrvcdir20swzlcm64va09nh5x8-source  <none>
Closure size: 2278 -> 2279 (80 paths added, 79 paths removed, delta +1, disk usage -1.4MiB).

Host: x280
<<< x280.current
>>> x280.next
Version changes:
[U.]  #1  bootspec           1.0.0 -> 1.0.1
[U.]  #2  gh-dash            4.15.0, 4.15.0-fish-completions -> 4.16.0, 4.16.0-fish-completions
[U.]  #3  libkate            0.4.1 -> 0.4.3
[U*]  #4  netbird            0.45.1 x2, 0.45.1-fish-completions, 0.45.1-wrapper-netbird -> 0.45.2 x2, 0.45.2-fish-completions, 0.45.2-wrapper-netbird
[U.]  #5  nixos-system-x280  25.11.20250531.910796c -> 25.11.20250603.c2a0396
[U.]  #6  ruff               0.11.11 -> 0.11.12
[U.]  #7  winbox             4.0beta20, 4.0beta20-fish-completions -> 4.0beta21, 4.0beta21-fish-completions
Added packages:
[A.]  #1  1zw47fx5h4x65n914j4b9iz0j3v17aw0-source  <none>
[A.]  #2  initrd-shells                            <none>
Removed packages:
[R.]  #1  dax78flrvcdir20swzlcm64va09nh5x8-source  <none>
Closure size: 2261 -> 2262 (80 paths added, 79 paths removed, delta +1, disk usage -1.4MiB).

Host: xeonixos
<<< xeonixos.current
>>> xeonixos.next
Version changes:
[U.]  #1  gh-dash                4.15.0, 4.15.0-fish-completions -> 4.16.0, 4.16.0-fish-completions
[U.]  #2  libkate                0.4.1 -> 0.4.3
[U*]  #3  netbird                0.45.1 x2, 0.45.1-fish-completions, 0.45.1-wrapper-netbird -> 0.45.2 x2, 0.45.2-fish-completions, 0.45.2-wrapper-netbird
[U.]  #4  nixos-system-xeonixos  25.11.20250531.910796c -> 25.11.20250603.c2a0396
[U.]  #5  ruff                   0.11.11 -> 0.11.12
[U.]  #6  winbox                 4.0beta20, 4.0beta20-fish-completions -> 4.0beta21, 4.0beta21-fish-completions
Added packages:
[A.]  #1  1zw47fx5h4x65n914j4b9iz0j3v17aw0-source  <none>
[A.]  #2  initrd-nixos.conf                        <none>
Removed packages:
[R.]  #1  dax78flrvcdir20swzlcm64va09nh5x8-source  <none>
[R.]  #2  unit-initrd.target                       <none>
Closure size: 2078 -> 2078 (81 paths added, 81 paths removed, delta +0, disk usage -1.4MiB).

```




