### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1727447169,
-        "narHash": "sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE+ne0U=",
+        "lastModified": 1749105467,
+        "narHash": "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "aa07eb05537d4cd025e2310397a6adcedfe72c76",
+        "rev": "6bc76b872374845ba9d645a2f012b764fecd765f",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748737919,
-        "narHash": "sha256-5kvBbLYdp+n7Ftanjcs6Nv+UO6sBhelp6MIGJ9nWmjQ=",
+        "lastModified": 1749221014,
+        "narHash": "sha256-mqrpuP/lfyDmta5hJWTwWgdF5lwdiubcGs7oRvcTZ2s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5675a9686851d9626560052a032c4e14e533c1fa",
+        "rev": "96482a538e6103579d254b139759d0536177370b",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748634340,
-        "narHash": "sha256-pZH4bqbOd8S+si6UcfjHovWDiWKiIGRNRMpmRWaDIms=",
+        "lastModified": 1749195551,
+        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "daa628a725ab4948e0e2b795e8fb6f4c3e289a7a",
+        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1748780463,
-        "narHash": "sha256-ractU3zRifAqWkUq+V6u1F1+QpdknTLZMm+34ne6CDE=",
+        "lastModified": 1749227334,
+        "narHash": "sha256-7XEr7qYYS5aWEzTjMJAGuCxes0PvQmEM6cXrWhH27+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8d7795a14435294d0b5f8cb1b8a9d791328a0ab",
+        "rev": "308e77ddac6ade9b4771711c16f8e603bd3fbfb9",
         "type": "github"
       },
       "original": {
@@ -429,11 +429,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748662220,
-        "narHash": "sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es=",
+        "lastModified": 1749174413,
+        "narHash": "sha256-urN9UMK5cd1dzhR+Lx0xHeTgBp2MatA5+6g9JaxjuQs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59138c7667b7970d205d6a05a8bfa2d78caa3643",
+        "rev": "6ad174a6dc07c7742fc64005265addf87ad08615",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748778828,
-        "narHash": "sha256-8S5G9xO7qoMMO2K85/mZSpFUJzgJJJF3xU5/mHuFJbY=",
+        "lastModified": 1749223883,
+        "narHash": "sha256-ax8x159Jc2hoWMYJkF5D6eKu58oJo4XzLU4YSk1hZhQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2786e3c51859ba35e77445105ba32d0a8f894a0f",
+        "rev": "2e6e71681b88ec9bc9c9914b413d1e875f8328c9",
         "type": "github"
       },
       "original": {
@@ -687,11 +687,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1748243702,
-        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
chore(deps): update flake inputs

This PR was generated automatically to update the flake inputs for the following attributes:
devShells.x86_64-linux.default

<details>
<summary>Flake update summary</summary>

```console
unpacking 'github:NixOS/nixpkgs/308e77ddac6ade9b4771711c16f8e603bd3fbfb9' into the Git cache...
warning: updating lock file '"/tmp/gh-flake-update.vGQIJBJFNG/worktree/flake.lock"':
• Updated input 'deploy-rs':
    'github:serokell/deploy-rs/aa07eb05537d4cd025e2310397a6adcedfe72c76?narHash=sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE%2Bne0U%3D' (2024-09-27)
  → 'github:serokell/deploy-rs/6bc76b872374845ba9d645a2f012b764fecd765f?narHash=sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE%3D' (2025-06-05)
• Updated input 'deploy-rs/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Updated input 'deploy-rs/utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725?narHash=sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8%3D' (2023-12-04)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
  → 'github:hercules-ci/flake-parts/49f0870db23e8c1ca0b5259734a02cd9e1e371a1?narHash=sha256-F82%2BgS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE%3D' (2025-06-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5675a9686851d9626560052a032c4e14e533c1fa?narHash=sha256-5kvBbLYdp%2Bn7Ftanjcs6Nv%2BUO6sBhelp6MIGJ9nWmjQ%3D' (2025-06-01)
  → 'github:nix-community/home-manager/96482a538e6103579d254b139759d0536177370b?narHash=sha256-mqrpuP/lfyDmta5hJWTwWgdF5lwdiubcGs7oRvcTZ2s%3D' (2025-06-06)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/daa628a725ab4948e0e2b795e8fb6f4c3e289a7a?narHash=sha256-pZH4bqbOd8S%2Bsi6UcfjHovWDiWKiIGRNRMpmRWaDIms%3D' (2025-05-30)
  → 'github:NixOS/nixos-hardware/4602f7e1d3f197b3cb540d5accf5669121629628?narHash=sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM%3D' (2025-06-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/910796cabe436259a29a72e8d3f5e180fc6dfacc?narHash=sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8%3D' (2025-05-31)
  → 'github:nixos/nixpkgs/c2a03962b8e24e669fb37b7df10e7c79531ff1a4?narHash=sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj%2BQ%3D' (2025-06-03)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/d8d7795a14435294d0b5f8cb1b8a9d791328a0ab?narHash=sha256-ractU3zRifAqWkUq%2BV6u1F1%2BQpdknTLZMm%2B34ne6CDE%3D' (2025-06-01)
  → 'github:NixOS/nixpkgs/308e77ddac6ade9b4771711c16f8e603bd3fbfb9?narHash=sha256-7XEr7qYYS5aWEzTjMJAGuCxes0PvQmEM6cXrWhH27%2BM%3D' (2025-06-06)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/59138c7667b7970d205d6a05a8bfa2d78caa3643?narHash=sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es%3D' (2025-05-31)
  → 'github:nixos/nixpkgs/6ad174a6dc07c7742fc64005265addf87ad08615?narHash=sha256-urN9UMK5cd1dzhR%2BLx0xHeTgBp2MatA5%2B6g9JaxjuQs%3D' (2025-06-06)
• Updated input 'nur':
    'github:nix-community/NUR/2786e3c51859ba35e77445105ba32d0a8f894a0f?narHash=sha256-8S5G9xO7qoMMO2K85/mZSpFUJzgJJJF3xU5/mHuFJbY%3D' (2025-06-01)
  → 'github:nix-community/NUR/2e6e71681b88ec9bc9c9914b413d1e875f8328c9?narHash=sha256-ax8x159Jc2hoWMYJkF5D6eKu58oJo4XzLU4YSk1hZhQ%3D' (2025-06-06)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/910796cabe436259a29a72e8d3f5e180fc6dfacc?narHash=sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8%3D' (2025-05-31)
  → 'github:nixos/nixpkgs/c2a03962b8e24e669fb37b7df10e7c79531ff1a4?narHash=sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj%2BQ%3D' (2025-06-03)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/1f3f7b784643d488ba4bf315638b2b0a4c5fb007?narHash=sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8%3D' (2025-05-26)
  → 'github:numtide/treefmt-nix/a05be418a1af1198ca0f63facb13c985db4cb3c5?narHash=sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk%3D' (2025-06-06)
```
</details>

<details>
<summary>✅ Attribute: <code>devShells.x86_64-linux.default</code> (Update Succeeded)</summary>

```diff
<<< /tmp/gh-flake-update.vGQIJBJFNG/devShells-x86_64-linux-default.current
>>> /tmp/gh-flake-update.vGQIJBJFNG/devShells-x86_64-linux-default.next
No version or selection state changes.
Closure size: 133 -> 133 (5 paths added, 5 paths removed, delta +0, disk usage +13.9KiB).
```
</details>
