### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756842514,
-        "narHash": "sha256-XbtRMewPGJwTNhBC4pnBu3w/xT1XejvB0HfohC2Kga8=",
+        "lastModified": 1757385184,
+        "narHash": "sha256-LCxtQn9ajvOgGRbQIRUJgfP7clMGGvV1SDW1HcSb0zk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30fc1b532645a21e157b6e33e3f8b4c154f86382",
+        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1756750488,
-        "narHash": "sha256-e4ZAu2sjOtGpvbdS5zo+Va5FUUkAnizl4wb0/JlIL2I=",
+        "lastModified": 1757103352,
+        "narHash": "sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH+q462Sn8lrmWmk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "47eb4856cfd01eaeaa7bb5944a0f27db8fb9b94a",
+        "rev": "11b2a10c7be726321bb854403fdeec391e798bf0",
         "type": "github"
       },
       "original": {
@@ -472,11 +472,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1756871276,
-        "narHash": "sha256-PjPMw3PSzkGcsGpfQMbKE03NsKNBBnFwbfPyEqjnX58=",
+        "lastModified": 1757429465,
+        "narHash": "sha256-WkY8GmWzlwvR2TlZh9/uVb/lryRuICIQGd+fuNYk6tI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37de9b4fdcfc9190c6ba3217f25d80dbfcf8cda",
+        "rev": "60bfd9f7d412d164545fcd350ab0842417e4aa33",
         "type": "github"
       },
       "original": {
@@ -504,11 +504,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1756819007,
-        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {
@@ -588,11 +588,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1756875847,
-        "narHash": "sha256-2L4kOvvCDUDBBBliCNiEXrYN0VqqkB0YHuOGckpp5X8=",
+        "lastModified": 1757423513,
+        "narHash": "sha256-IniS9dykLck4jCCE2DgIDpsfeYyZTHmsous+upy+fwM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bffccde9bd7869ab355b76d53fbc25ac1f7d37eb",
+        "rev": "53d822bcb1826b21845f3b350d8dfa71b47ca045",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR was generated automatically to update the flake inputs.

<details>
<summary>Flake update summary (from commit message)</summary>

```console
unpacking 'github:NixOS/nixpkgs/60bfd9f7d412d164545fcd350ab0842417e4aa33' into the Git cache...
warning: updating lock file '"/tmp/gh-flake-update.JJlzZw4uKr/worktree/flake.lock"':
• Updated input 'git-hooks':
    'github:cachix/git-hooks.nix/e891a93b193fcaf2fc8012d890dc7f0befe86ec2?narHash=sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs%3D' (2025-08-23)
  → 'github:cachix/git-hooks.nix/ab82ab08d6bf74085bd328de2a8722c12d97bd9d?narHash=sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM%3D' (2025-09-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/30fc1b532645a21e157b6e33e3f8b4c154f86382?narHash=sha256-XbtRMewPGJwTNhBC4pnBu3w/xT1XejvB0HfohC2Kga8%3D' (2025-09-02)
  → 'github:nix-community/home-manager/26993d87fd0d3b14f7667b74ad82235f120d986e?narHash=sha256-LCxtQn9ajvOgGRbQIRUJgfP7clMGGvV1SDW1HcSb0zk%3D' (2025-09-09)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/47eb4856cfd01eaeaa7bb5944a0f27db8fb9b94a?narHash=sha256-e4ZAu2sjOtGpvbdS5zo%2BVa5FUUkAnizl4wb0/JlIL2I%3D' (2025-09-01)
  → 'github:NixOS/nixos-hardware/11b2a10c7be726321bb854403fdeec391e798bf0?narHash=sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH%2Bq462Sn8lrmWmk%3D' (2025-09-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d0fc30899600b9b3466ddb260fd83deb486c32f1?narHash=sha256-rw/PHa1cqiePdBxhF66V7R%2BWAP8WekQ0mCDG4CFqT8Y%3D' (2025-09-02)
  → 'github:nixos/nixpkgs/b599843bad24621dcaa5ab60dac98f9b0eb1cabe?narHash=sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL%2Bnma8o%3D' (2025-09-08)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/c37de9b4fdcfc9190c6ba3217f25d80dbfcf8cda?narHash=sha256-PjPMw3PSzkGcsGpfQMbKE03NsKNBBnFwbfPyEqjnX58%3D' (2025-09-03)
  → 'github:NixOS/nixpkgs/60bfd9f7d412d164545fcd350ab0842417e4aa33?narHash=sha256-WkY8GmWzlwvR2TlZh9/uVb/lryRuICIQGd%2BfuNYk6tI%3D' (2025-09-09)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/aaff8c16d7fc04991cac6245bee1baa31f72b1e1?narHash=sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2%2BcIGmhz3nrE%3D' (2025-09-02)
  → 'github:nixos/nixpkgs/ca77296380960cd497a765102eeb1356eb80fed0?narHash=sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao%3D' (2025-09-05)
• Updated input 'nur':
    'github:nix-community/NUR/bffccde9bd7869ab355b76d53fbc25ac1f7d37eb?narHash=sha256-2L4kOvvCDUDBBBliCNiEXrYN0VqqkB0YHuOGckpp5X8%3D' (2025-09-03)
  → 'github:nix-community/NUR/53d822bcb1826b21845f3b350d8dfa71b47ca045?narHash=sha256-IniS9dykLck4jCCE2DgIDpsfeYyZTHmsous%2Bupy%2BfwM%3D' (2025-09-09)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d0fc30899600b9b3466ddb260fd83deb486c32f1?narHash=sha256-rw/PHa1cqiePdBxhF66V7R%2BWAP8WekQ0mCDG4CFqT8Y%3D' (2025-09-02)
  → 'github:nixos/nixpkgs/b599843bad24621dcaa5ab60dac98f9b0eb1cabe?narHash=sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL%2Bnma8o%3D' (2025-09-08)
```

</details>

<details>
<summary>Attribute: <code>nixosConfigurations.x13.config.system.build.toplevel</code> (Diff)</summary>

```console
<<< /tmp/gh-flake-update.JJlzZw4uKr/nixosConfigurations-x13-config-system-build-toplevel.current
>>> /nix/store/rr9sn53pq41x9w3v5nxd1fpir4q6ss64-nixos-system-x13-25.11.20250908.b599843

CHANGED
[U*] bind                                    9.20.11-host, 9.20.11-lib -> 9.20.12-host, 9.20.12-lib
[U.] chromium                                139.0.7258.154, 139.0.7258.154-sandbox -> 140.0.7339.80, 140.0.7339.80-sandbox
[U.] chromium-unwrapped                      139.0.7258.154, 139.0.7258.154-sandbox -> 140.0.7339.80, 140.0.7339.80-sandbox
[U*] cpupower                                6.16.4, 6.16.4_fish-completions -> 6.16.5, 6.16.5_fish-completions
[U.] dix                                     1.2.2 -> 1.3.0
[U.] electron                                36.8.1 -> 37.4.0
[U.] electron-unwrapped                      36.8.1 -> 37.4.0
[U.] exiv2                                   0.28.5, 0.28.5-lib -> 0.28.7, 0.28.7-lib
[U.] initrd-linux                            6.16.4 -> 6.16.5
[U.] jujutsu                                 0.32.0, 0.32.0-fish-completions -> 0.33.0, 0.33.0-fish-completions
[U.] lazygit                                 0.54.2, 0.54.2-fish-completions -> 0.55.0, 0.55.0-fish-completions
[U.] linux                                   6.16.4, 6.16.4-modules ×2, 6.16.4-modules-shrunk -> 6.16.5, 6.16.5-modules ×2, 6.16.5-modules-shrunk
[U.] mergiraf                                0.13.0, 0.13.0-fish-completions -> 0.14.0, 0.14.0-fish-completions
[U.] mesa                                    25.2.1 -> 25.2.2
[U*] netbird-client                          0.55.1, 0.55.1-wrapper-netbird -> 0.56.0, 0.56.0-wrapper-netbird
[U.] netbird-ui                              0.55.1 -> 0.56.0
[U*] nix                                     2.28.4, 2.28.4-man -> 2.28.5, 2.28.5-man
[U.] nixos-system-x13                        25.11.20250902.d0fc308 -> 25.11.20250908.b599843
[U.] opencv                                  4.11.0 ×2 -> 4.12.0 ×2
[U.] runc                                    1.3.0 -> 1.3.1
[U.] signal-desktop                          7.66.0, 7.66.0-fish-completions -> 7.68.0, 7.68.0-fish-completions
[U*] udisks                                  2.10.1, 2.10.1-man -> 2.10.2, 2.10.2-man
[U.] vscode-extension-golang-Go              0.48.0 -> 0.50.0
[U.] webkitgtk                               2.48.5+abi=4.1 -> 2.48.6+abi=4.1
[U*] wireplumber                             0.5.10 -> 0.5.11
[U.] zed-editor                              0.201.8, 0.201.8-fish-completions -> 0.202.7, 0.202.7-fish-completions

ADDED
[A.] 5izw1shpjxb9qhlf67bx427cih5czj8w-source <none>
[A.] initrd-nixos.conf                       <none>

REMOVED
[R.] 8vfhnwmmzqqzy97q9c5m4bzyaqqf63zy-source <none>
[R.] initrd-bin-env                          <none>

SIZE: 14.4 GiB -> 14.4 GiB
DIFF: 27.2 MiB
```

</details>
